### PR TITLE
exported getFlashPlayerFolder function

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,6 +28,8 @@ function getFlashPlayerConfigFolder() {
     return path.join(getFlashPlayerFolder(), '#Security', 'FlashPlayerTrust');
 }
 
+module.exports.getFlashPlayerFolder = getFlashPlayerFolder;
+
 module.exports.initSync = function (appName) {
     
     var trusted = [];

--- a/main.js
+++ b/main.js
@@ -28,8 +28,6 @@ function getFlashPlayerConfigFolder() {
     return path.join(getFlashPlayerFolder(), '#Security', 'FlashPlayerTrust');
 }
 
-module.exports.getFlashPlayerFolder = getFlashPlayerFolder;
-
 module.exports.initSync = function (appName) {
     
     var trusted = [];

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@
 var fs = require('fs');
 var os = require('os');
 var path = require('path');
+var mkdirp = require('mkdirp');
 
 function getFlashPlayerFolder() {
     switch (process.platform) {
@@ -79,8 +80,12 @@ module.exports.initSync = function (appName) {
         
         cfgPath = getFlashPlayerFolder();
         if (!fs.existsSync(cfgPath)) {
-            // if this folder is not present then there is nothing I can do
-            throw new Error('Flash Player config folder not found.');
+            // if this folder is not present then try to create it
+            try {
+                mkdirp.sync(cfgPath);
+            } catch(err) {
+                throw new Error('Could not create Flash Player config folder.');
+            }
         }
         
         // Adding next parts to path one after another and checking if they exist

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nw-flash-trust",
   "author": "Jakub Szwacz <jakub@szwacz.com>",
   "description": "Flash Player trusted locations manager for node-webkit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "main.js",
   "homepage": "https://github.com/szwacz/nw-flash-trust",
   "repository": {


### PR DESCRIPTION
(and raised version)

This is why I needed that:
I'm using nw.js with builtin Flash plugin libraries in my releases (raw libs, like .so, .dll).
So FlashPlayer is not necessarily installed on the platform, but the application have the flash plugin and can run flash files.
This export lets me check externally if the folder is present on the system, and lets me create it if needed to be able to use nw-flash-trust.

BTW I'm curious about why you don't create the folder if it does not exist ? Is this your check for knowing flash is not installed on the platform ? (https://github.com/szwacz/nw-flash-trust/blob/master/main.js#L82)

Anyway, as detecting presence of flash with a 100% accuracy is not easy, and because this usecase is quite specific, I thought that exporting the function was the best way of doing this.