### PR TITLE
Support chrome-extension:// protocol, changes for folder locator on latest windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,23 @@ var flashTrust = require('nw-flash-trust');
 // appName could be any globally unique string containing only
 // big and small letters, numbers and chars "-._"
 // It specifies name of file where trusted paths will be stored.
-// Best practice is to feed it with "name" value from your package.json file.
+// This must be same as "name" value from your package.json file.
 var appName = 'myApp';
 
 // Initialization and parsing config file for given appName (if already exists).
-var trustManager = flashTrust.initSync(appName);
+// If you are using latest NW.js, it is currently using chrome-extension:// protocol
+// To address local files. So you will probably want to set nwChromeExtensionsProtocol
+// to true within options object (This might need to be left as false or undefined for Electron)
+var trustManager = flashTrust.initSync(appName, {
+    nwChromeExtensionsProtocol: true
+});
 
 // Alternatively you can provide a custom flash config folder for initialization.
 // This is useful for example if you use Atom Electron and a PPAPI flash plugin (like Pepper Flash),
 // as the flash config folder in this case would be in the Atom Electron data path folder.
-var trustManager = flashTrust.initSync(appName, '/yourApp-data-path/Pepper Data/Shockwave Flash/WritableRoot');
+var trustManager = flashTrust.initSync(appName, { 
+    customFolder: '/yourApp-data-path/Pepper Data/Shockwave Flash/WritableRoot' 
+});
 
 // adds given filepath to trusted locations
 // paths must be absolute

--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ var trustManager = flashTrust.initSync(appName, {
     customFolder: '/yourApp-data-path/Pepper Data/Shockwave Flash/WritableRoot' 
 });
 
+
+// if nwChromeExtensionsProtocol set to true in initSync's options
+// object, this adds whole current folder to trusted locations
+trustManager.add("");
+
+// if nwChromeExtensionsProtocol set to true in initSync's options
+// object, this adds local file test.swf in root folder of your project
+// to trsuted locations
+trustManager.add("test.swf");
+
+// following examples are for file:// protocol i.e. for
+// a scenario where nwChromeExtensionsProtocol is not set
+// or set to false in initSync's options object
+
 // adds given filepath to trusted locations
 // paths must be absolute
 trustManager.add(path.resolve('path-to', 'file.swf'));

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Long story short: you have to put text file in special directory provided by Fla
 ## Installation
 
 ```
-npm install nw-flash-trust
+npm install nw-flash-trust-a
 ```
 
 ## Usage & API
@@ -22,7 +22,7 @@ For simplicity API is fully synchronous. It does a little of I/O, but so little 
 
 ```javascript
 var path = require('path');
-var flashTrust = require('nw-flash-trust');
+var flashTrust = require('nw-flash-trust-a');
 
 // appName could be any globally unique string containing only
 // big and small letters, numbers and chars "-._"

--- a/main.js
+++ b/main.js
@@ -19,8 +19,9 @@ function getFlashPlayerFolder(options) {
 				//return process.env.USERPROFILE + '\\AppData\\Local\\'+ meta.name +'\\User Data\\Default\\Pepper Data\\Shockwave Flash\\System';
 			}
 		case 'darwin':
-			// osx
-			return process.env.HOME + '/Library/Preferences/Macromedia/Flash Player';
+            // osx
+            return process.env.HOME + `/Library/Application Support/${options.appName}/Default/Pepper Data/Shockwave Flash/Shockwave Flash/WritableRoot`;
+			//return process.env.HOME + '/Library/Preferences/Macromedia/Flash Player';
 		case 'linux':
 			return process.env.HOME + '/.macromedia/Flash_Player';
 	}
@@ -36,8 +37,8 @@ function getFlashPlayerConfigFolder(options) {
 
 /**
  * 
- * @param {String} appName - appName from package.json
- * @param {Object/String} options - options object or just custom folder (string)
+ * @param {string} appName - appName from package.json
+ * @param {object|string} options - options object or just custom folder (string)
  */
 module.exports.initSync = function (appName, options) {
     

--- a/main.js
+++ b/main.js
@@ -58,7 +58,7 @@ module.exports.initSync = function (appName, options) {
     function add(path) {
         path = path || "";
         if (options.nwChromeExtensionsProtocol) {
-            path = "chrome-extension://looopdimgeckeofmcaiaibhmghiooned"+path;
+            path = `chrome-extension://${chrome.runtime.id}/${path}`;
         }
         if (!isTrusted(path)) { 
             trusted.push(path);

--- a/main.js
+++ b/main.js
@@ -20,7 +20,7 @@ function getFlashPlayerFolder(options) {
 			}
 		case 'darwin':
             // osx
-            return process.env.HOME + `/Library/Application Support/${options.appName}/Default/Pepper Data/Shockwave Flash/Shockwave Flash/WritableRoot`;
+            return process.env.HOME + `/Library/Application Support/${options.appName}/Default/Pepper Data/Shockwave Flash/WritableRoot`;
 			//return process.env.HOME + '/Library/Preferences/Macromedia/Flash Player';
 		case 'linux':
 			return process.env.HOME + '/.macromedia/Flash_Player';

--- a/package.json
+++ b/package.json
@@ -1,16 +1,34 @@
 {
-  "name": "nw-flash-trust",
+  "name": "nw-flash-trust-a",
   "author": "Jakub Szwacz <jakub@szwacz.com>",
   "description": "Flash Player trusted locations manager for NW.js and Atom Electron",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "main.js",
-  "homepage": "https://github.com/szwacz/nw-flash-trust",
+  "homepage": "https://github.com/aikei/nw-flash-trust",
   "repository": {
     "type": "git",
-    "url": "https://github.com/szwacz/nw-flash-trust.git"
+    "url": "git+https://github.com/aikei/nw-flash-trust.git"
   },
   "licence": "MIT",
   "dependencies": {
     "mkdirp": "^0.5.1"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/aikei/nw-flash-trust/issues"
+  },
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "flash",
+    "as3",
+    "flash-trust",
+    "nw.js",
+    "nwjs",
+    "nw"
+  ],
+  "license": "ISC"
 }

--- a/package.json
+++ b/package.json
@@ -2,19 +2,19 @@
   "name": "nw-flash-trust-a",
   "author": "Jakub Szwacz <jakub@szwacz.com> / aikei <andrwknight@gmail.com>",
   "description": "Flash Player trusted locations manager for NW.js and Atom Electron",
-  "version": "0.4.3",
+  "version": "0.4.6",
   "main": "main.js",
-  "homepage": "https://github.com/szwacz/nw-flash-trust",
+  "homepage": "https://github.com/aikei/nw-flash-trust",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/szwacz/nw-flash-trust.git"
+    "url": "git+https://github.com/aikei/nw-flash-trust.git"
   },
   "licence": "MIT",
   "dependencies": {
     "mkdirp": "^0.5.1"
   },
   "bugs": {
-    "url": "https://github.com/szwacz/nw-flash-trust/issues"
+    "url": "https://github.com/aikei/nw-flash-trust/issues"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "nw-flash-trust-a",
-  "author": "Jakub Szwacz <jakub@szwacz.com>",
+  "author": "Jakub Szwacz <jakub@szwacz.com> / aikei <andrwknight@gmail.com>",
   "description": "Flash Player trusted locations manager for NW.js and Atom Electron",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "main": "main.js",
   "homepage": "https://github.com/szwacz/nw-flash-trust",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,17 +4,17 @@
   "description": "Flash Player trusted locations manager for NW.js and Atom Electron",
   "version": "0.4.0",
   "main": "main.js",
-  "homepage": "https://github.com/aikei/nw-flash-trust",
+  "homepage": "https://github.com/szwacz/nw-flash-trust",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aikei/nw-flash-trust.git"
+    "url": "git+https://github.com/szwacz/nw-flash-trust.git"
   },
   "licence": "MIT",
   "dependencies": {
     "mkdirp": "^0.5.1"
   },
   "bugs": {
-    "url": "https://github.com/aikei/nw-flash-trust/issues"
+    "url": "https://github.com/szwacz/nw-flash-trust/issues"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nw-flash-trust-a",
   "author": "Jakub Szwacz <jakub@szwacz.com>",
   "description": "Flash Player trusted locations manager for NW.js and Atom Electron",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "main": "main.js",
   "homepage": "https://github.com/aikei/nw-flash-trust",
   "repository": {


### PR DESCRIPTION
Added solution from @kanda-shellka in issue https://github.com/szwacz/nw-flash-trust/issues/8 which improves FlashTrustFolder location: on latest versions of windows, it is instead placed under `AppData/${app-name}` instead of `AppData/Google/Chrome`.
Also added an options object as the second argument to `initSync`, in which you can do two things: 1) select custom folder for FlashTrustFolder , 2) select local file protocol: `file://` (default) or `chrome-extension://`. Latest versions of NW.js only support `chrome-extension://` protocol. So if user selects this protocol, we will add `chrome-extension://${extensionId}` in front of the file name being added to trust storage.
Also made related README changes.